### PR TITLE
Fix off-by-one column loop (IndexError) and remove redundant shift calculation

### DIFF
--- a/dewarp-rectify.py
+++ b/dewarp-rectify.py
@@ -296,9 +296,10 @@ def uncurve_text(input_path, output_path, n_splines, arc_equal=False):
 
     # Roll each column to align the text
     for i in range(leftmost_x, rightmost_x + 1):
-        image[:, i, 0] = np.roll(image[:, i, 0], round(y_hat[i - leftmost_x] - thresh.shape[0]/2))
-        image[:, i, 1] = np.roll(image[:, i, 1], round(y_hat[i - leftmost_x] - thresh.shape[0]/2))
-        image[:, i, 2] = np.roll(image[:, i, 2], round(y_hat[i - leftmost_x] - thresh.shape[0]/2))
+        shift = round(y_hat[i - leftmost_x] - thresh.shape[0]/2)
+        image[:, i, 0] = np.roll(image[:, i, 0], shift)
+        image[:, i, 1] = np.roll(image[:, i, 1], shift)
+        image[:, i, 2] = np.roll(image[:, i, 2], shift)
   
     # Plot the final image
     plt.imshow(image[:,:,::-1])

--- a/dewarp-rectify.py
+++ b/dewarp-rectify.py
@@ -316,5 +316,5 @@ if __name__ == "__main__":
     final_path = './sports_final.png'
     n1_splines = 6
     n2_splines = 9
-    uncurve_text_tight(input_path, output_path, n1_splines, arc_equal=True))
-    uncurve_text(output_path, final_path, n2_splines, arc_equal=False))
+    uncurve_text_tight(input_path, output_path, n1_splines, arc_equal=True)
+    uncurve_text(output_path, final_path, n2_splines, arc_equal=False)

--- a/dewarp.py
+++ b/dewarp.py
@@ -33,10 +33,11 @@ def dewarp_text(input_path, output_path, n_splines = 5):
     plt.show()
 
     # Roll each column to align the text
-    for i in range(image.shape[1] + 1):
-        image[:, i, 0] = np.roll(image[:, i, 0], round(y_hat[i] - thresh.shape[0]/2))
-        image[:, i, 1] = np.roll(image[:, i, 1], round(y_hat[i] - thresh.shape[0]/2))
-        image[:, i, 2] = np.roll(image[:, i, 2], round(y_hat[i] - thresh.shape[0]/2))
+    for i in range(image.shape[1]):
+        shift = round(thresh.shape[0]/2 - y_hat[i])
+        image[:, i, 0] = np.roll(image[:, i, 0], shift)
+        image[:, i, 1] = np.roll(image[:, i, 1], shift)
+        image[:, i, 2] = np.roll(image[:, i, 2], shift)
 
     # Plot the final image
     plt.imshow(image[:,:,::-1])

--- a/tight_dewarp.py
+++ b/tight_dewarp.py
@@ -35,9 +35,10 @@ def uncurve_text(input_path, output_path, n_splines = 5):
 
     # Roll each column to align the text
     for i in range(leftmost_x, rightmost_x + 1):
-        image[:, i, 0] = np.roll(image[:, i, 0], round(y_hat[i - leftmost_x] - thresh.shape[0]/2))
-        image[:, i, 1] = np.roll(image[:, i, 1], round(y_hat[i - leftmost_x] - thresh.shape[0]/2))
-        image[:, i, 2] = np.roll(image[:, i, 2], round(y_hat[i - leftmost_x] - thresh.shape[0]/2))
+        shift = round(y_hat[i - leftmost_x] - thresh.shape[0]/2)
+        image[:, i, 0] = np.roll(image[:, i, 0], shift)
+        image[:, i, 1] = np.roll(image[:, i, 1], shift)
+        image[:, i, 2] = np.roll(image[:, i, 2], shift)
 
     # Plot the final image
     plt.imshow(image[:,:,::-1])


### PR DESCRIPTION
This PR fixes:
* An off-by-one error in the per-column roll loop that caused an IndexError at the last iteration by correctly looping through the nubmer of columsn in the image.
`IndexError: index 5789 is out of bounds for axis 1 with size 5789`
 * Removes per-channel shift computations recomputed for each color channel unnecessarily.
 * Removes an extra bracket in the function call leading to syntax errors.